### PR TITLE
Allow chunked restart sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ git clone https://github.com/ssitu/ComfyUI_restart_sampling
 
 The Restart sampler nodes can be found in the node menu under `sampling`.
 
+If you set the environment variable `COMFYUI_VERBOSE_RESTART_SAMPLING` to `1`, restart sampling will dump
+information about the steps it's going to run to the console.
+
 ### Nodes
 
 |Node|Image|Description|
@@ -36,6 +39,21 @@ Both $t_{\textrm{min}}$ and $t_{\textrm{max}}$ within a segment definition may b
 * A quoted string percentage value followed by a percent sign (i.e. `"25%"`) — note that this refers to the percentage of sampling, not the percentage of steps that have elapsed.
 
 You may freely mix the different formats. For example, `[2, 2, -500, "10%"], [3, 2, 5.3, -3]` would be a valid sequence. Note: Random numbers used for example only, not recommended.
+
+**Special segment values**:
+
+* Enter `default` to use the default segment list.
+* Enter `a1111` to emulate A1111 WebUI's segment calculation behavior.
+For full emulation, enabled chunked mode, set both schedulers to `karras` and the sampler to `heun`.
+
+### Chunked Mode
+
+When chunked mode is enabled, the sampler is called with as many steps as possible up to the next segment. When disabled, the sampler
+is only called with a single step at a time. Some samplers such as SDE samplers, momentum samplers, second order samplers
+like dpmpp_2m use state from previous steps - when called step-by-step, this state is lost. Using chunked mode may make those
+samplers more accurate.
+
+*Note*: Using SDE or momentum samplers with restart is likely not an improvement over normal sampling.
 
 ## Visual Example
 

--- a/nodes.py
+++ b/nodes.py
@@ -48,7 +48,7 @@ class KRestartSamplerSimple:
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise, segments, chunked_mode=False):
+    def sample(self, model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise, segments):
         return restart_sampling(model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, segments, scheduler, denoise=denoise)
 
 
@@ -77,7 +77,7 @@ class KRestartSampler:
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise, segments, restart_scheduler, chunked_mode=False):
+    def sample(self, model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise, segments, restart_scheduler, chunked_mode=True):
         return restart_sampling(model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, segments, restart_scheduler, denoise=denoise, chunked_mode=chunked_mode)
 
 
@@ -110,7 +110,7 @@ class KRestartSamplerAdv:
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, chunked_mode=False):
+    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, chunked_mode=True):
         force_full_denoise = return_with_leftover_noise != "enable"
         disable_noise = add_noise == "disable"
         return restart_sampling(model, noise_seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, chunked_mode=chunked_mode)
@@ -146,7 +146,7 @@ class KRestartSamplerCustom:
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, chunked_mode=False):
+    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, chunked_mode=True):
         force_full_denoise = return_with_leftover_noise != "enable"
         disable_noise = add_noise == "disable"
         return restart_sampling(model, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, output_only=False, chunked_mode=chunked_mode)

--- a/nodes.py
+++ b/nodes.py
@@ -137,7 +137,7 @@ class KRestartSamplerCustom:
                 "return_with_leftover_noise": (["disable", "enable"], ),
                 "segments": ("STRING", {"default": DEFAULT_SEGMENTS, "multiline": False}),
                 "restart_scheduler": (get_supported_restart_schedulers(), ),
-            },
+            }
         }
 
     RETURN_TYPES = ("LATENT","LATENT")
@@ -172,7 +172,7 @@ class KRestartSamplerCustomNoise:
                 "return_with_leftover_noise": (["disable", "enable"], ),
                 "segments": ("STRING", {"default": DEFAULT_SEGMENTS, "multiline": False}),
                 "restart_scheduler": (get_supported_restart_schedulers(),),
-                "chunked_mode": (["disable", "enable"], ),
+                "chunked_mode": ("BOOLEAN", {"default": False}),
             },
             "optional": {
                 "custom_noise_opt": ("SONAR_CUSTOM_NOISE",),
@@ -187,7 +187,7 @@ class KRestartSamplerCustomNoise:
     def sample(self, model, add_noise, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, custom_noise_opt=None, chunked_mode="disable"):
         force_full_denoise = return_with_leftover_noise != "enable"
         disable_noise = add_noise == "disable"
-        return restart_sampling(model, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, output_only=False, custom_noise=custom_noise_opt, chunked_mode=chunked_mode=="enable")
+        return restart_sampling(model, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, output_only=False, custom_noise=custom_noise_opt.make_noise_sampler if custom_noise_opt else None, chunked_mode=chunked_mode)
 
 NODE_CLASS_MAPPINGS = {
     "KRestartSamplerSimple": KRestartSamplerSimple,

--- a/nodes.py
+++ b/nodes.py
@@ -137,7 +137,10 @@ class KRestartSamplerCustom:
                 "return_with_leftover_noise": (["disable", "enable"], ),
                 "segments": ("STRING", {"default": DEFAULT_SEGMENTS, "multiline": False}),
                 "restart_scheduler": (get_supported_restart_schedulers(), ),
-            }
+            },
+            "optional": {
+                "custom_noise_opt": ("SONAR_CUSTOM_NOISE",),
+            },
         }
 
     RETURN_TYPES = ("LATENT","LATENT")
@@ -145,10 +148,10 @@ class KRestartSamplerCustom:
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler):
+    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, custom_noise_opt=None):
         force_full_denoise = return_with_leftover_noise != "enable"
         disable_noise = add_noise == "disable"
-        return restart_sampling(model, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, output_only=False)
+        return restart_sampling(model, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, output_only=False, custom_noise=custom_noise_opt)
 
 
 NODE_CLASS_MAPPINGS = {

--- a/nodes.py
+++ b/nodes.py
@@ -172,6 +172,7 @@ class KRestartSamplerCustomNoise:
                 "return_with_leftover_noise": (["disable", "enable"], ),
                 "segments": ("STRING", {"default": DEFAULT_SEGMENTS, "multiline": False}),
                 "restart_scheduler": (get_supported_restart_schedulers(),),
+                "chunked_mode": (["disable", "enable"], ),
             },
             "optional": {
                 "custom_noise_opt": ("SONAR_CUSTOM_NOISE",),
@@ -183,10 +184,10 @@ class KRestartSamplerCustomNoise:
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, custom_noise_opt=None):
+    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, custom_noise_opt=None, chunked_mode="disable"):
         force_full_denoise = return_with_leftover_noise != "enable"
         disable_noise = add_noise == "disable"
-        return restart_sampling(model, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, output_only=False, custom_noise=custom_noise_opt)
+        return restart_sampling(model, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, output_only=False, custom_noise=custom_noise_opt, chunked_mode=chunked_mode=="enable")
 
 NODE_CLASS_MAPPINGS = {
     "KRestartSamplerSimple": KRestartSamplerSimple,

--- a/restart_sampling.py
+++ b/restart_sampling.py
@@ -54,10 +54,10 @@ def prepare_restart_segments(restart_info, ms, sigmas):
             return []
         if steps < 36:
             # Less than 36 steps - one restart with 9 steps.
-            restart_info = "[10,1,0.1,0.2]"
+            restart_info = "[10, 1, 0.1, 2.0]"
         else:
             # Otherwise two restarts with steps // 4 steps.
-            restart_info = f"[{(steps // 4) + 1}, 2, 0.1, 0.2]"
+            restart_info = f"[{(steps // 4) + 1}, 2, 0.1, 2.0]"
     try:
         restart_arrays = ast.literal_eval(f"[{restart_info}]")
     except SyntaxError as e:

--- a/restart_sampling.py
+++ b/restart_sampling.py
@@ -88,7 +88,7 @@ def calc_restart_steps(restart_segments):
     return restart_steps
 
 
-def restart_sampling(model, seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, restart_info, restart_scheduler, denoise=1.0, disable_noise=False, step_range=None, force_full_denoise=False, output_only=True, custom_noise=None, noise_multiplier=1.0, chunked_mode=False):
+def restart_sampling(model, seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, restart_info, restart_scheduler, denoise=1.0, disable_noise=False, step_range=None, force_full_denoise=False, output_only=True, custom_noise=None, chunked_mode=False):
     if isinstance(sampler, str):
         sampler = sampler_object(sampler)
 


### PR DESCRIPTION
@ssitu this isn't ready yet, but i wanted to check if you were interested in this approach. 

(note: i don't plan to leave the custom noise node in, but i'd love it if the backend support for custom noise could remain. also always explaining the plan is just temporarily enabled for debug purposes)

the main change is this adds a chunked restart sampling mode which divides the sigmas into segments that can be handed to the sampling function rather than giving it only a single step at a time. i _believe_ this also makes it work more like the a1111 version which keeps state for the second order stuff (though it only supports heun as far as i know). with the current comfy implementation, samplers like dpmpp_2m get fresh state every step, heunpp2 just runs an euler step if the second sigma is the last one (which also would be the case when passing single steps).

with chunked mode disabled it should work exactly the same as the current version. non-chunked mode could be the default and possibly a toggle added to the new custom sampler node.

by the way, in case you're wondering what the custom noise stuff is about - i have a bunch of custom noise stuff here: https://github.com/blepping/ComfyUI-sonar . with the backend support in place, i could import restart sampling as a module and enable a restart sampler node with custom noise input without having to maintain a separate fork. other people could potentially use that i guess, but there's probably no one else crazy enough to want to use non-gaussian noise with restart sampling. :)