### PR TITLE
Code formatting + clean up some lints

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -1,5 +1,6 @@
 import comfy
-from .restart_sampling import restart_sampling, SCHEDULER_MAPPING, DEFAULT_SEGMENTS
+
+from .restart_sampling import DEFAULT_SEGMENTS, SCHEDULER_MAPPING, restart_sampling
 
 
 def get_supported_samplers():
@@ -27,129 +28,273 @@ def get_supported_restart_schedulers():
 
 class KRestartSamplerSimple:
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
-                "model": ("MODEL", ),
-                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "model": ("MODEL",),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF}),
                 "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                 "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0}),
-                "sampler_name": (get_supported_samplers(), ),
-                "scheduler": (comfy.samplers.KSampler.SCHEDULERS, ),
-                "positive": ("CONDITIONING", ),
-                "negative": ("CONDITIONING", ),
-                "latent_image": ("LATENT", ),
-                "denoise": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "sampler_name": (get_supported_samplers(),),
+                "scheduler": (comfy.samplers.KSampler.SCHEDULERS,),
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "latent_image": ("LATENT",),
+                "denoise": (
+                    "FLOAT",
+                    {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01},
+                ),
                 "segments": ("STRING", {"default": "default", "multiline": False}),
-            }
+            },
         }
 
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise, segments):
-        return restart_sampling(model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, segments, scheduler, denoise=denoise)
+    def sample(
+        self,
+        model,
+        seed,
+        steps,
+        cfg,
+        sampler_name,
+        scheduler,
+        positive,
+        negative,
+        latent_image,
+        denoise,
+        segments,
+    ):
+        return restart_sampling(
+            model,
+            seed,
+            steps,
+            cfg,
+            sampler_name,
+            scheduler,
+            positive,
+            negative,
+            latent_image,
+            segments,
+            scheduler,
+            denoise=denoise,
+        )
 
 
 class KRestartSampler:
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
-                "model": ("MODEL", ),
-                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "model": ("MODEL",),
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF}),
                 "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                 "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0}),
-                "sampler_name": (get_supported_samplers(), ),
-                "scheduler": (tuple(SCHEDULER_MAPPING.keys()), ),
-                "positive": ("CONDITIONING", ),
-                "negative": ("CONDITIONING", ),
-                "latent_image": ("LATENT", ),
-                "denoise": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
-                "segments": ("STRING", {"default": DEFAULT_SEGMENTS, "multiline": False}),
-                "restart_scheduler": (get_supported_restart_schedulers(), ),
+                "sampler_name": (get_supported_samplers(),),
+                "scheduler": (tuple(SCHEDULER_MAPPING.keys()),),
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "latent_image": ("LATENT",),
+                "denoise": (
+                    "FLOAT",
+                    {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01},
+                ),
+                "segments": (
+                    "STRING",
+                    {"default": DEFAULT_SEGMENTS, "multiline": False},
+                ),
+                "restart_scheduler": (get_supported_restart_schedulers(),),
                 "chunked_mode": ("BOOLEAN", {"default": True}),
-            }
+            },
         }
 
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, denoise, segments, restart_scheduler, chunked_mode=True):
-        return restart_sampling(model, seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, segments, restart_scheduler, denoise=denoise, chunked_mode=chunked_mode)
+    def sample(
+        self,
+        model,
+        seed,
+        steps,
+        cfg,
+        sampler_name,
+        scheduler,
+        positive,
+        negative,
+        latent_image,
+        denoise,
+        segments,
+        restart_scheduler,
+        chunked_mode=True,
+    ):
+        return restart_sampling(
+            model,
+            seed,
+            steps,
+            cfg,
+            sampler_name,
+            scheduler,
+            positive,
+            negative,
+            latent_image,
+            segments,
+            restart_scheduler,
+            denoise=denoise,
+            chunked_mode=chunked_mode,
+        )
 
 
 class KRestartSamplerAdv:
-
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
                 "model": ("MODEL",),
-                "add_noise": (["enable", "disable"], ),
-                "noise_seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "add_noise": (["enable", "disable"],),
+                "noise_seed": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF},
+                ),
                 "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                 "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0}),
-                "sampler_name": (get_supported_samplers(), ),
-                "scheduler": (tuple(SCHEDULER_MAPPING.keys()), ),
-                "positive": ("CONDITIONING", ),
-                "negative": ("CONDITIONING", ),
-                "latent_image": ("LATENT", ),
+                "sampler_name": (get_supported_samplers(),),
+                "scheduler": (tuple(SCHEDULER_MAPPING.keys()),),
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "latent_image": ("LATENT",),
                 "start_at_step": ("INT", {"default": 0, "min": 0, "max": 10000}),
                 "end_at_step": ("INT", {"default": 10000, "min": 0, "max": 10000}),
-                "return_with_leftover_noise": (["disable", "enable"], ),
-                "segments": ("STRING", {"default": DEFAULT_SEGMENTS, "multiline": False}),
-                "restart_scheduler": (get_supported_restart_schedulers(), ),
+                "return_with_leftover_noise": (["disable", "enable"],),
+                "segments": (
+                    "STRING",
+                    {"default": DEFAULT_SEGMENTS, "multiline": False},
+                ),
+                "restart_scheduler": (get_supported_restart_schedulers(),),
                 "chunked_mode": ("BOOLEAN", {"default": True}),
-            }
+            },
         }
 
     RETURN_TYPES = ("LATENT",)
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, chunked_mode=True):
+    def sample(
+        self,
+        model,
+        add_noise,
+        noise_seed,
+        steps,
+        cfg,
+        sampler_name,
+        scheduler,
+        positive,
+        negative,
+        latent_image,
+        start_at_step,
+        end_at_step,
+        return_with_leftover_noise,
+        segments,
+        restart_scheduler,
+        chunked_mode=True,
+    ):
         force_full_denoise = return_with_leftover_noise != "enable"
         disable_noise = add_noise == "disable"
-        return restart_sampling(model, noise_seed, steps, cfg, sampler_name, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, chunked_mode=chunked_mode)
+        return restart_sampling(
+            model,
+            noise_seed,
+            steps,
+            cfg,
+            sampler_name,
+            scheduler,
+            positive,
+            negative,
+            latent_image,
+            segments,
+            restart_scheduler,
+            disable_noise=disable_noise,
+            step_range=(start_at_step, end_at_step),
+            force_full_denoise=force_full_denoise,
+            chunked_mode=chunked_mode,
+        )
 
 
 class KRestartSamplerCustom:
-
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
         return {
             "required": {
                 "model": ("MODEL",),
-                "add_noise": (["enable", "disable"], ),
-                "noise_seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                "add_noise": (["enable", "disable"],),
+                "noise_seed": (
+                    "INT",
+                    {"default": 0, "min": 0, "max": 0xFFFFFFFFFFFFFFFF},
+                ),
                 "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
                 "cfg": ("FLOAT", {"default": 8.0, "min": 0.0, "max": 100.0}),
-                "sampler": ("SAMPLER", ),
-                "scheduler": (tuple(SCHEDULER_MAPPING.keys()), ),
-                "positive": ("CONDITIONING", ),
-                "negative": ("CONDITIONING", ),
-                "latent_image": ("LATENT", ),
+                "sampler": ("SAMPLER",),
+                "scheduler": (tuple(SCHEDULER_MAPPING.keys()),),
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "latent_image": ("LATENT",),
                 "start_at_step": ("INT", {"default": 0, "min": 0, "max": 10000}),
                 "end_at_step": ("INT", {"default": 10000, "min": 0, "max": 10000}),
-                "return_with_leftover_noise": (["disable", "enable"], ),
-                "segments": ("STRING", {"default": DEFAULT_SEGMENTS, "multiline": False}),
-                "restart_scheduler": (get_supported_restart_schedulers(), ),
+                "return_with_leftover_noise": (["disable", "enable"],),
+                "segments": (
+                    "STRING",
+                    {"default": DEFAULT_SEGMENTS, "multiline": False},
+                ),
+                "restart_scheduler": (get_supported_restart_schedulers(),),
                 "chunked_mode": ("BOOLEAN", {"default": True}),
-            }
+            },
         }
 
-    RETURN_TYPES = ("LATENT","LATENT")
+    RETURN_TYPES = ("LATENT", "LATENT")
     RETURN_NAMES = ("output", "denoised_output")
     FUNCTION = "sample"
     CATEGORY = "sampling"
 
-    def sample(self, model, add_noise, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, start_at_step, end_at_step, return_with_leftover_noise, segments, restart_scheduler, chunked_mode=True):
+    def sample(
+        self,
+        model,
+        add_noise,
+        noise_seed,
+        steps,
+        cfg,
+        sampler,
+        scheduler,
+        positive,
+        negative,
+        latent_image,
+        start_at_step,
+        end_at_step,
+        return_with_leftover_noise,
+        segments,
+        restart_scheduler,
+        chunked_mode=True,
+    ):
         force_full_denoise = return_with_leftover_noise != "enable"
         disable_noise = add_noise == "disable"
-        return restart_sampling(model, noise_seed, steps, cfg, sampler, scheduler, positive, negative, latent_image, segments, restart_scheduler, disable_noise=disable_noise, step_range=(start_at_step, end_at_step), force_full_denoise=force_full_denoise, output_only=False, chunked_mode=chunked_mode)
+        return restart_sampling(
+            model,
+            noise_seed,
+            steps,
+            cfg,
+            sampler,
+            scheduler,
+            positive,
+            negative,
+            latent_image,
+            segments,
+            restart_scheduler,
+            disable_noise=disable_noise,
+            step_range=(start_at_step, end_at_step),
+            force_full_denoise=force_full_denoise,
+            output_only=False,
+            chunked_mode=chunked_mode,
+        )
+
 
 NODE_CLASS_MAPPINGS = {
     "KRestartSamplerSimple": KRestartSamplerSimple,


### PR DESCRIPTION
as promised!

this is 95% cosmetic - just ran it through a code formatter and made some style changes (like consistently ending list items with a comma even when it's not strictly necessary, sorting imports).

stuff like:
 
```python
    sigs = [float(s_max)]
    for x in range(1, n - 1):
        sigs += [float(sigmas_slice[-(1 + int(x * ss))])]
    sigs += [float(s_min), 0.0]
```

can be written more succinctly by unpacking a comprehension. actually didn't know about this trick until the linter suggested it:

```plaintext
>>> (1, 2, *(x for x in range(4)), 3, 4, 5)
(1, 2, 0, 1, 2, 3, 3, 4, 5)
```

so if you want to build a sequence with a prefix/suffix it's possible to just unpack a comprehension in the middle. since those immediately get turned into tensors, they didn't even need to be lists and could be immutable tuples instead.

these changes shouldn't affect the results in any way.

the formatting/linter is opinionated and this didn't take much effort so if you prefer the existing style please feel free to simply close this pull.